### PR TITLE
Naive implementation of batch support

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -63,7 +63,10 @@ def calculate_weight_patched(self: ModelPatcher, patches, weight, key):
     remaining = []
 
     for p in patches:
-        alpha, v, strength_model = p
+        alpha = p[0]
+        v = p[1]
+        strength_model = p[2]
+        # alpha, v, strength_model = p
 
         is_fooocus_patch = isinstance(v, tuple) and len(v) == 2 and v[0] == "fooocus"
         if not is_fooocus_patch:
@@ -158,7 +161,11 @@ class ApplyFooocusInpaint:
 
         def input_block_patch(h, transformer_options):
             if transformer_options["block"][1] == 0:
-                h = h + inpaint_head_feature.to(h)
+                hh = inpaint_head_feature.to(h)
+                if hh.shape[0] > 1:
+                    batch_size = int(h.shape[0]/hh.shape[0])
+                    hh = hh.repeat(batch_size, 1, 1, 1)
+                h = h + hh
             return h
 
         lora_keys = comfy.lora.model_lora_keys_unet(model.model, {})

--- a/nodes.py
+++ b/nodes.py
@@ -223,6 +223,15 @@ class MaskedFill:
     FUNCTION = "fill"
 
     def fill(self, image: Tensor, mask: Tensor, fill: str, falloff: int):
+        assert image.shape[0] == mask.shape[0], "Masks and images must have the same batch size"
+        batch_size = image.shape[0]
+        result = []
+        for i in range(batch_size):
+            result += self._fill_single(image[i].unsqueeze(0), mask[i], fill, falloff)[0]
+
+        return (torch.stack(result),)
+
+    def _fill_single(self, image: Tensor, mask: Tensor, fill: str, falloff: int):
         image = image.detach().clone()
         alpha = mask.expand(1, *mask.shape[-2:]).floor()
         falloff = make_odd(falloff)


### PR DESCRIPTION
Iterate over all images and call the fill functionality for each image sequentially and then stack the results back together.

It’s probably gonna be much faster to do it with single tensor, but I don’t have time to figure that out. If someone knows how to do that, please feel free to send a patch, or tell me how to do it.