### PR TITLE
Fix calculate_weight_patched to handle variable-length patches

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -66,8 +66,14 @@ def calculate_weight_patched(self: ModelPatcher, patches, weight, key):
     remaining = []
 
     for p in patches:
+        if not isinstance(p, (tuple, list)) or len(p) < 2:
+            # Skip invalid patches
+            print(f"[ApplyFooocusInpaint] Skipping invalid patch: {p}")
+            continue
+
         alpha = p[0]
         v = p[1]
+        strength_model = p[2] if len(p) > 2 else None
 
         is_fooocus_patch = isinstance(v, tuple) and len(v) == 2 and v[0] == "fooocus"
         if not is_fooocus_patch:
@@ -89,6 +95,7 @@ def calculate_weight_patched(self: ModelPatcher, patches, weight, key):
 
     if len(remaining) > 0:
         return original_calculate_weight(self, remaining, weight, key)
+        
     return weight
 
 


### PR DESCRIPTION
 updates the calculate_weight_patched function to handle patches with varying numbers of elements. It now safely unpacks patch data, skips invalid patches, and maintains compatibility with both Fooocus and standard patches. This change resolves the 'too many values to unpack' error